### PR TITLE
Fix Typo in "Sending Data to Telex" Documentation

### DIFF
--- a/docs/Integrations/creating_integration.md
+++ b/docs/Integrations/creating_integration.md
@@ -200,6 +200,6 @@ As mentioned earlier, an interval integration will only need the target URL if i
 
 #### Sending Data to Telex
 
-For interval integrations, Telex will send a return_url in its /tick_url request so that the integration can send back to the channel after its done processing. 
+For interval integrations, Telex will send a return_url in its /tick_url request so that the integration can send back to the channel after it's done processing.
 
-NB: This is only available to the interval_inregrations.
+NB: This is only available to the interval integrations.


### PR DESCRIPTION
## PR Description
This PR corrects a typo in the documentation under the `Creating Integrations` "Sending Data to Telex" section. The original text has been corrected to improve readability and accuracy.

## Changes Made
- Fixed the typo: "interval_inregrations" → "interval integrations" in the Telex documentation.
- Change `its` to `it's`

## Screenshots
**Before:**
![image](https://github.com/user-attachments/assets/8892b99d-dc9f-4be9-9b6f-284db709ae58)
**After:**
![image](https://github.com/user-attachments/assets/817c8233-697f-414e-ad6b-7005d5f4f737)

## Why is this important?
- Enhances clarity and professionalism in the documentation.
- Ensures correctness for future readers and developers referencing the docs.
