### PR TITLE
docs: add 'warning' as a valid status in integrations

### DIFF
--- a/docs/Integrations/creating_integration.md
+++ b/docs/Integrations/creating_integration.md
@@ -202,9 +202,15 @@ As mentioned earlier, an interval integration will only need the target URL if i
 
 For interval integrations, Telex will send a return_url in its /tick_url request so that the integration can send back to the channel after it's done processing.
 
+##### Status Values
+
+Integrations must return a `status` field with one of the following values:
+
+- `success`: Indicates that the operation was completed successfully.
+- `error`: Indicates that an error occurred.
+- `warning`: Indicates a non-critical issue that requires attention but does not completely break the system.
+
 NB: This is only available to the interval integrations.
-
-
 
 ### Output Integration Type
 


### PR DESCRIPTION
## PR Description
This PR updates the Telex documentation to support `"warning"` as a valid status value for integrations. The current documentation only mentions `"success"` and `"error"`, but `"warning"` is necessary for cases where an issue is important but not critical.

This addition ensures that developers can send **non-critical alerts** to Telex channels, improving monitoring and observability.

## Changes Made
- Updated the **Creating Integrations** documentation to include `"warning"` as a valid status.
- Described the use case for `"warning"` in the status field.
- Added `"warning"` as an example status in the JSON payload.

## Screenshots
**Before:**
![image](https://github.com/user-attachments/assets/8892b99d-dc9f-4be9-9b6f-284db709ae58)
**After:**
![image](https://github.com/user-attachments/assets/5a6353db-36b7-44f7-93f6-db8874de4e68)

## Why is this important?
- **Enhances flexibility:** Developers can now distinguish between errors and warnings.
- **Improves monitoring:** Non-critical alerts (e.g., memory nearing limit, high response times) can be reported without triggering an "error."
- **Maintains consistency:** Ensures Telex can handle different levels of system health notifications.
